### PR TITLE
Fix tweet URL

### DIFF
--- a/neigefr/templates/_head_js.html
+++ b/neigefr/templates/_head_js.html
@@ -25,7 +25,7 @@
 
         L.marker([{{ snowflake.latitude }}, {{ snowflake.longitude }}], {icon: flake_icon}).addTo(map)
             .bindPopup('<h4>{{ snowflake.zipcode }}{% if snowflake.rank %} ({{ snowflake.rank }}/10){% endif %}</h4>'
-                + "<img class='tweet_picture' src='{{ snowflake.tweet_object.user.profile_image_url }}' alt='Image {{ snowflake.tweet_object.user.screen_name }}' /><p><a target='_blank' href='https://twitter.com/#!/{{ snowflake.tweet_object.tweet_object.user.screen_name }}/status/{{ snowflake.tweet_id }}'>@{{ snowflake.tweet_object.user.screen_name }}</a> - <i class=\"icon-time\"></i> {{ snowflake.tweet_time }}<br>{{ snowflake.tweet_object.text|force_escape|escapejs }}<br></p>");
+                + "<img class='tweet_picture' src='{{ snowflake.tweet_object.user.profile_image_url }}' alt='Image {{ snowflake.tweet_object.user.screen_name }}' /><p><a target='_blank' href='https://twitter.com/{{ snowflake.tweet_object.user.screen_name }}/status/{{ snowflake.tweet_id }}'>@{{ snowflake.tweet_object.user.screen_name }}</a> - <i class=\"icon-time\"></i> {{ snowflake.tweet_time }}<br>{{ snowflake.tweet_object.text|force_escape|escapejs }}<br></p>");
         {% endfor %}
 
     }


### PR DESCRIPTION
A typo introduced to retrieve the `screen_name` in URL generates a broken link. Also remove useless shebang.